### PR TITLE
fix: urls are prefixed with /realtime/realtimekit

### DIFF
--- a/src/content/docs/realtime/realtimekit/guides/index.mdx
+++ b/src/content/docs/realtime/realtimekit/guides/index.mdx
@@ -24,37 +24,37 @@ Learn how to use key features of RealtimeKit, such as recording, breakout rooms,
 
 <CardGrid>
 	<LinkCard
-		href="/guides/capabilities/recording/recording-overview"
+		href="/realtime/realtimekit/guides/capabilities/recording/recording-overview"
 		title="Recording"
 		description="Understand RealtimeKit's recording capabilities and record audio, video, whiteboard and other custom elements"
 		icon="record"
 	/>
 	<LinkCard
-		href="/guides/capabilities/webinar/intro-webinar"
+		href="/realtime/realtimekit/guides/capabilities/webinar/intro-webinar"
 		title="Webinar"
 		description="Leverage RealtimeKit's Webinar feature for one-to-many events with larger audiences."
 		icon="webinar"
 	/>
 	<LinkCard
-		href="/guides/capabilities/webhooks/webhooks-overview"
+		href="/realtime/realtimekit/guides/capabilities/webhooks/webhooks-overview"
 		title="Webhooks & Events"
 		description="Utilize webhooks to push real-time updates to your server."
 		icon="webhooks"
 	/>
 	<LinkCard
-		href="/guides/capabilities/breakoutroom/introduction-breakout-rooms"
+		href="/realtime/realtimekit/guides/capabilities/breakoutroom/introduction-breakout-rooms"
 		title="Breakout Rooms"
 		description="Facilitate focused discussions and collaboration with breakout rooms."
 		icon="breakout-rooms"
 	/>
 	<LinkCard
-		href="/guides/capabilities/misc/embed"
+		href="/realtime/realtimekit/guides/capabilities/misc/embed"
 		title="No Code Integration"
 		description="Integrate RealtimeKit into your project using an iFrame, eliminating the need for SDKs."
 		icon="no-code"
 	/>
 	<LinkCard
-		href="/guides/capabilities/chat/export-chat-dump"
+		href="/realtime/realtimekit/guides/capabilities/chat/export-chat-dump"
 		title="Export chat"
 		description="Retrieve all chat messages of a RealtimeKit meeting through the REST API"
 		icon="chat"
@@ -67,7 +67,7 @@ Learn the basics of working with RealtimeKit's REST APIs.
 
 <CardGrid>
 	<LinkCard
-		href="/guides/rest-apis/quickstart"
+		href="/realtime/realtimekit/guides/rest-apis/quickstart"
 		title="REST APIs"
 		description="Understand how our REST APIs work and how to get started with them"
 		icon="rest-api"

--- a/src/content/docs/realtime/realtimekit/index.mdx
+++ b/src/content/docs/realtime/realtimekit/index.mdx
@@ -18,19 +18,19 @@ Integrate programmable, and easily customizable live video and voice into your w
 
 <CardGrid>
 	<LinkCard
-		href="/guides/live-video/intro-video-conf"
+		href="/realtime/realtimekit/guides/live-video/intro-video-conf"
 		title="Live Video Calls"
 		description="Enable live video communication within your application using WebRTC. Perfect for education, telemedicine, social networks and gaming"
 		icon="video"
 	/>
 	<LinkCard
-		href="/guides/voice-conf/intro-voice-conf"
+		href="/realtime/realtimekit/guides/voice-conf/intro-voice-conf"
 		title="Voice Calls"
 		description="Incorporate high-quality real-time audio into your application using WebRTC. Build voice calls, audio conferences, voice chats in games and more"
 		icon="mic"
 	/>
 	<LinkCard
-		href="/guides/livestream/livestream-overview"
+		href="/realtime/realtimekit/guides/livestream/livestream-overview"
 		title="Interactive Live Streaming"
 		description="Integrate highly scalable live video broadcasting capabilities into your app using HLS, ideal for apps that involve streaming webinars, sports or live events"
 		icon="live"
@@ -44,5 +44,5 @@ Integrate programmable, and easily customizable live video and voice into your w
 	variant="secondary"
 	href="https://dash.realtime.cloudflare.com/dashboard"
 >
-	RealtimeKit dashboard
+	RealtimeKit Dashboard
 </LinkButton>

--- a/src/content/docs/realtime/realtimekit/partials/_product-section.mdx
+++ b/src/content/docs/realtime/realtimekit/partials/_product-section.mdx
@@ -15,19 +15,19 @@ import {
 
 <CardGrid>
 	<LinkCard
-		href="/guides/live-video/intro-video-conf"
+		href="/realtime/realtimekit/guides/live-video/intro-video-conf"
 		title="Live Video"
 		description="Enable live video communication within your application using WebRTC. Perfect for education, telemedicine, social networks and gaming."
 		icon="video-camera"
 	/>
 	<LinkCard
-		href="/guides/voice-conf/intro-voice-conf"
+		href="/realtime/realtimekit/guides/voice-conf/intro-voice-conf"
 		title="Voice Conferencing"
 		description="Integrate reliable voice calling experiences into your product."
 		icon="phone"
 	/>
 	<LinkCard
-		href="/guides/livestream/livestream-overview"
+		href="/realtime/realtimekit/guides/livestream/livestream-overview"
 		title="Interactive Live Streaming"
 		description="Get started with interactive livestreaming and broadcast to a large audience."
 		icon="broadcast"


### PR DESCRIPTION
### Summary

URLs in Realtime are prefixed with `/realtime/realtimekit`
<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
